### PR TITLE
Change resume redirect to r2 storage

### DIFF
--- a/content/r/resume.md
+++ b/content/r/resume.md
@@ -1,4 +1,4 @@
 ---
 title: "Resume"
-redirect_url: https://assets.ianmcg.dev/public/IanMcGillivaryResume.pdf 
+redirect_url: https://r2.ianmcg.dev/IanMcGillivaryResume.pdf 
 ---


### PR DESCRIPTION
Changed resume redirect link to use new Cloudflare R2 storage rather than self-hosted webdav server for better reliability and access times. 